### PR TITLE
Feature/add support for vmss roles

### DIFF
--- a/roles.tf
+++ b/roles.tf
@@ -108,6 +108,7 @@ locals {
     subscriptions                              = local.combined_objects_subscriptions
     synapse_workspaces                         = local.combined_objects_synapse_workspaces
     virtual_subnets                            = local.combined_objects_virtual_subnets
+    virtual_machine_scale_sets                 = local.combined_objects_virtual_machine_scale_sets
     log_analytics                              = local.current_objects_log_analytics
   }
 

--- a/shared_image_gallery.tf
+++ b/shared_image_gallery.tf
@@ -53,7 +53,7 @@ module "packer_service_principal" {
   depends_on = [
     module.shared_image_galleries,
     module.image_definitions,
-    azurerm_role_assignment.for,
+    #azurerm_role_assignment.for, # NOTE: Deactivated this direct dependency due to Cycle error
   ]
 }
 
@@ -79,6 +79,6 @@ module "packer_build" {
   depends_on = [
     module.shared_image_galleries,
     module.image_definitions,
-    azurerm_role_assignment.for,
+    #azurerm_role_assignment.for, # NOTE: Deactivated this direct dependency due to Cycle error
   ]
 }

--- a/storage_account_blobs.tf
+++ b/storage_account_blobs.tf
@@ -3,7 +3,7 @@
 #
 
 resource "time_sleep" "delay" {
-  depends_on = [azurerm_role_assignment.for]
+  #depends_on = [azurerm_role_assignment.for] # NOTE: Deactivated this direct dependency due to Cycle error
   for_each   = local.storage.storage_account_blobs
 
   create_duration = "300s"

--- a/virtual_machines_scale_sets.tf
+++ b/virtual_machines_scale_sets.tf
@@ -8,11 +8,11 @@ module "virtual_machine_scale_sets" {
     module.keyvault_access_policies,
     module.keyvault_access_policies_azuread_apps,
     module.proximity_placement_groups,
-    # module.load_balancers, # This is used in line #32 and therefore should have the same issue
+    module.load_balancers,
     module.application_gateways,
     module.application_security_groups,
-    #module.packer_service_principal, # This leads to cycle as well
-    #module.packer_build,# This leads to cycle as well
+    module.packer_service_principal,
+    module.packer_build,
     module.proximity_placement_groups
   ]
   for_each = local.compute.virtual_machine_scale_sets
@@ -28,7 +28,7 @@ module "virtual_machine_scale_sets" {
   global_settings                  = local.global_settings
   image_definitions                = local.combined_objects_image_definitions
   keyvaults                        = local.combined_objects_keyvaults
-  load_balancers                   = "x" #local.combined_objects_load_balancers # Enabling this leads to cycle error
+  load_balancers                   = local.combined_objects_load_balancers
   lbs                              = local.combined_objects_lb
   lb_backend_address_pool          = local.combined_objects_lb_backend_address_pool
   managed_identities               = local.combined_objects_managed_identities

--- a/virtual_machines_scale_sets.tf
+++ b/virtual_machines_scale_sets.tf
@@ -17,11 +17,11 @@ module "virtual_machine_scale_sets" {
   ]
   for_each = local.compute.virtual_machine_scale_sets
 
-  availability_sets                =  local.combined_objects_availability_sets
-  application_gateways             =  local.combined_objects_application_gateways
-  application_security_groups      =  local.combined_objects_application_security_groups
-  base_tags                        =  try(local.global_settings.inherit_tags, false) ? try(local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags, {}) : {}
-  boot_diagnostics_storage_account =  try(local.combined_diagnostics.storage_accounts[each.value.boot_diagnostics_storage_account_key].primary_blob_endpoint, {})
+  availability_sets                = local.combined_objects_availability_sets
+  application_gateways             = local.combined_objects_application_gateways
+  application_security_groups      = local.combined_objects_application_security_groups
+  base_tags                        = try(local.global_settings.inherit_tags, false) ? try(local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags, {}) : {}
+  boot_diagnostics_storage_account = try(local.combined_diagnostics.storage_accounts[each.value.boot_diagnostics_storage_account_key].primary_blob_endpoint, {})
   client_config                    = local.client_config
   diagnostics                      = local.combined_diagnostics
   disk_encryption_sets             = local.combined_objects_disk_encryption_sets

--- a/virtual_machines_scale_sets.tf
+++ b/virtual_machines_scale_sets.tf
@@ -8,27 +8,27 @@ module "virtual_machine_scale_sets" {
     module.keyvault_access_policies,
     module.keyvault_access_policies_azuread_apps,
     module.proximity_placement_groups,
-    module.load_balancers,
+    # module.load_balancers, # This is used in line #32 and therefore should have the same issue
     module.application_gateways,
     module.application_security_groups,
-    module.packer_service_principal,
-    module.packer_build,
+    #module.packer_service_principal, # This leads to cycle as well
+    #module.packer_build,# This leads to cycle as well
     module.proximity_placement_groups
   ]
   for_each = local.compute.virtual_machine_scale_sets
 
-  availability_sets                = local.combined_objects_availability_sets
-  application_gateways             = local.combined_objects_application_gateways
-  application_security_groups      = local.combined_objects_application_security_groups
-  base_tags                        = try(local.global_settings.inherit_tags, false) ? try(local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags, {}) : {}
-  boot_diagnostics_storage_account = try(local.combined_diagnostics.storage_accounts[each.value.boot_diagnostics_storage_account_key].primary_blob_endpoint, {})
+  availability_sets                =  local.combined_objects_availability_sets
+  application_gateways             =  local.combined_objects_application_gateways
+  application_security_groups      =  local.combined_objects_application_security_groups
+  base_tags                        =  try(local.global_settings.inherit_tags, false) ? try(local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags, {}) : {}
+  boot_diagnostics_storage_account =  try(local.combined_diagnostics.storage_accounts[each.value.boot_diagnostics_storage_account_key].primary_blob_endpoint, {})
   client_config                    = local.client_config
   diagnostics                      = local.combined_diagnostics
   disk_encryption_sets             = local.combined_objects_disk_encryption_sets
   global_settings                  = local.global_settings
   image_definitions                = local.combined_objects_image_definitions
   keyvaults                        = local.combined_objects_keyvaults
-  load_balancers                   = local.combined_objects_load_balancers
+  load_balancers                   = "x" #local.combined_objects_load_balancers # Enabling this leads to cycle error
   lbs                              = local.combined_objects_lb
   lb_backend_address_pool          = local.combined_objects_lb_backend_address_pool
   managed_identities               = local.combined_objects_managed_identities
@@ -46,4 +46,3 @@ module "virtual_machine_scale_sets" {
 output "virtual_machine_scale_sets" {
   value = module.virtual_machine_scale_sets
 }
-


### PR DESCRIPTION
### Description

To allow a more restrictive permission set on VMSS (e.g. for a Azure DevOps Service Connection) I want to assign the Contributor role to an identity.


### New or Affected Resource(s

azurerm

### Potential Configuration file

```hcl
role_mapping = {
  built_in_role_mapping = {
    virtual_machine_scale_sets = {
      vmss1 = {
        "Contributor" = {
          azuread_apps = {
            keys = ["example_app"]
          }
        }
      }
    }
  }
}
```