### PR TITLE
Allow to reference locally created subnets from remotely created virt…

### DIFF
--- a/application_gateways.tf
+++ b/application_gateways.tf
@@ -19,6 +19,7 @@ module "application_gateways" {
   sku_name                         = each.value.sku_name
   sku_tier                         = each.value.sku_tier
   vnets                            = local.combined_objects_networking
+  virtual_subnets                  = local.combined_objects_virtual_subnets
 
   application_gateway_applications = {
     for key, value in local.networking.application_gateway_applications : key => value
@@ -32,10 +33,8 @@ module "application_gateways" {
 
 output "application_gateways" {
   value = module.application_gateways
-
 }
 
 output "application_gateway_applications" {
   value = local.networking.application_gateway_applications
-
 }

--- a/modules/compute/virtual_machine/network_interface.tf
+++ b/modules/compute/virtual_machine/network_interface.tf
@@ -55,7 +55,7 @@ resource "azurerm_network_interface" "nic" {
 
   ip_configuration {
     name                          = azurecaf_name.nic[each.key].result
-    subnet_id                     = can(each.value.subnet_id) ? each.value.subnet_id : var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+    subnet_id                     = can(each.value.subnet_id) ? each.value.subnet_id : try(var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id, var.virtual_subnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.subnet_key].id)
     private_ip_address_allocation = lookup(each.value, "private_ip_address_allocation", "Dynamic")
     private_ip_address_version    = lookup(each.value, "private_ip_address_version", null)
     private_ip_address            = lookup(each.value, "private_ip_address", null)

--- a/modules/compute/virtual_machine/variables.tf
+++ b/modules/compute/virtual_machine/variables.tf
@@ -27,6 +27,8 @@ variable "settings" {}
 
 variable "vnets" {}
 
+variable "virtual_subnets" {}
+
 # Security
 variable "public_key_pem_file" {
   default     = ""

--- a/modules/networking/application_gateway/locals.networking.tf
+++ b/modules/networking/application_gateway/locals.networking.tf
@@ -5,12 +5,20 @@ locals {
     try(var.vnets[var.client_config.landingzone_key][var.settings.subnet.vnet_key], null)
   ), null)
 
+  gateway_virtual_subnets_local = try(coalesce(
+    try(var.virtual_subnets[var.client_config.landingzone_key][var.settings.subnet_key], null),
+  ), null)
+
   private_vnet_local = try(var.vnets[var.client_config.landingzone_key][var.settings.front_end_ip_configurations.private.vnet_key], null)
   public_vnet_local  = try(var.vnets[var.client_config.landingzone_key][var.settings.front_end_ip_configurations.public.vnet_key], null)
 
   gateway_vnet_remote = try(coalesce(
     try(var.vnets[var.settings.lz_key][var.settings.vnet_key], null),
     try(var.vnets[var.settings.subnet.lz_key][var.settings.subnet.vnet_key], null)
+  ), null)
+
+  gateway_virtual_subnets_remote = try(coalesce(
+    try(var.virtual_subnets[var.settings.subnet.lz_key][var.settings.subnet.subnet_key], null)
   ), null)
 
   private_vnet_remote = try(var.vnets[var.settings.front_end_ip_configurations.private.lz_key][var.settings.front_end_ip_configurations.private.vnet_key], null)
@@ -24,6 +32,7 @@ locals {
     gateway = {
       subnet_id = coalesce(
         try(local.gateway_vnet.subnets[var.settings.subnet_key].id, null),
+        try(var.virtual_subnets[var.client_config.landingzone_key][var.settings.subnet_key].id, null),
         try(var.settings.subnet_id, null)
       )
     }

--- a/modules/networking/application_gateway/locals.networking.tf
+++ b/modules/networking/application_gateway/locals.networking.tf
@@ -12,6 +12,9 @@ locals {
   private_vnet_local = try(var.vnets[var.client_config.landingzone_key][var.settings.front_end_ip_configurations.private.vnet_key], null)
   public_vnet_local  = try(var.vnets[var.client_config.landingzone_key][var.settings.front_end_ip_configurations.public.vnet_key], null)
 
+  private_subnets_local = try(var.virtual_subnets[var.client_config.landingzone_key], null)
+  public_subnets_local = try(var.virtual_subnets[var.client_config.landingzone_key], null)
+
   gateway_vnet_remote = try(coalesce(
     try(var.vnets[var.settings.lz_key][var.settings.vnet_key], null),
     try(var.vnets[var.settings.subnet.lz_key][var.settings.subnet.vnet_key], null)
@@ -23,6 +26,9 @@ locals {
 
   private_vnet_remote = try(var.vnets[var.settings.front_end_ip_configurations.private.lz_key][var.settings.front_end_ip_configurations.private.vnet_key], null)
   public_vnet_remote  = try(var.vnets[var.settings.front_end_ip_configurations.public.lz_key][var.settings.front_end_ip_configurations.public.vnet_key], null)
+
+  private_subnets_remote = try(var.virtual_subnets[var.settings.front_end_ip_configurations.private.lz_key], null)
+  public_subnets_remote = try(var.virtual_subnets[var.settings.front_end_ip_configurations.public.lz_key], null)
 
   gateway_vnet = merge(local.gateway_vnet_local, local.gateway_vnet_remote)
   private_vnet = merge(local.private_vnet_local, local.private_vnet_remote)

--- a/modules/networking/application_gateway/variable.tf
+++ b/modules/networking/application_gateway/variable.tf
@@ -24,7 +24,9 @@ variable "app_services" {
 variable "vnets" {
   default = {}
 }
-
+variable "virtual_subnets" {
+  default = {}
+}
 variable "sku_name" {
   type        = string
   default     = "Standard_v2"

--- a/virtual_machines.tf
+++ b/virtual_machines.tf
@@ -33,6 +33,7 @@ module "virtual_machines" {
   settings                    = each.value
   storage_accounts            = local.combined_objects_storage_accounts
   vnets                       = local.combined_objects_networking
+  virtual_subnets             = local.combined_objects_virtual_subnets
 
   # if boot_diagnostics_storage_account_key is points to a valid storage account, pass the endpoint
   # if boot_diagnostics_storage_account_key is empty string, pass empty string


### PR DESCRIPTION
# [1340](https://github.com/aztfmod/terraform-azurerm-caf/issues/1340)


## Description

A locally created subnet in a remotely created vnet can be specified as gateway subnet

## Does this introduce a breaking change

- [ ] YES
- [X] NO

## Testing

See [1340](https://github.com/aztfmod/terraform-azurerm-caf/issues/1340) for example configuration.
