### PR TITLE
fix(network-monitor): adding outputs to be referenced

### DIFF
--- a/local.remote_objects.tf
+++ b/local.remote_objects.tf
@@ -84,6 +84,7 @@ locals {
     mssql_servers                                  = try(local.combined_objects_mssql_servers, null)
     mysql_servers                                  = try(local.combined_objects_mysql_servers, null)
     nat_gateways                                   = try(local.combined_objects_nat_gateways, null)
+    network_connection_monitors                    = try(local.combined_objects_network_connection_monitors, null)
     network_security_groups                        = try(local.combined_objects_network_security_groups, null)
     network_watchers                               = try(local.combined_objects_network_watchers, null)
     networking                                     = try(local.combined_objects_networking, null)

--- a/locals.combined_objects.tf
+++ b/locals.combined_objects.tf
@@ -104,6 +104,7 @@ locals {
   combined_objects_mysql_flexible_server                          = merge(tomap({ (local.client_config.landingzone_key) = module.mysql_flexible_server }), try(var.remote_objects.mysql_flexible_server, {}))
   combined_objects_mysql_servers                                  = merge(tomap({ (local.client_config.landingzone_key) = module.mysql_servers }), try(var.remote_objects.mysql_servers, {}))
   combined_objects_nat_gateways                                   = merge(tomap({ (local.client_config.landingzone_key) = module.nat_gateways }), try(var.remote_objects.nat_gateways, {}))
+  combined_objects_network_connection_monitors                    = merge(tomap({ (local.client_config.landingzone_key) = module.network_connection_monitors }), try(var.remote_objects.network_connection_monitors, {}))
   combined_objects_network_profiles                               = merge(tomap({ (local.client_config.landingzone_key) = module.network_profiles }), try(var.remote_objects.network_profiles, {}))
   combined_objects_network_security_groups                        = merge(tomap({ (local.client_config.landingzone_key) = module.network_security_groups }), try(var.remote_objects.network_security_groups, {}))
   combined_objects_network_watchers                               = merge(tomap({ (local.client_config.landingzone_key) = module.network_watchers }), try(var.remote_objects.network_watchers, {}))

--- a/modules/networking/network_connection_monitor/output.tf
+++ b/modules/networking/network_connection_monitor/output.tf
@@ -1,1 +1,5 @@
 
+output "id" {
+  value       = azurerm_network_connection_monitor.connection_monitor.id
+  description = "The ID of the onnection_monitor"
+}


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
