### PR TITLE
fix: adding lifecylce rule to azurerm_private_dns_resolver_forwarding…

### DIFF
--- a/modules/networking/private_dns_resolvers_forwarding_rules/module.tf
+++ b/modules/networking/private_dns_resolvers_forwarding_rules/module.tf
@@ -11,7 +11,7 @@ data "azurecaf_name" "pvtdnsrfr" {
 
 
 resource "azurerm_private_dns_resolver_forwarding_rule" "pvt_dns_resolver_forwarding_rule" {
-  name                      = data.azurecaf_name.pvtdnsrfr.result
+  name                      = data.azurecaf_name.pvtdnsrfr.result //random name changes are a reported issue, can not find the reason right now. https://github.com/aztfmod/terraform-azurerm-caf/issues/1730. Lifecycle rule is a workaround...
   dns_forwarding_ruleset_id = var.dns_forwarding_ruleset_id
   domain_name               = var.settings.domain_name
   enabled                   = try(var.settings.enabled, null)


### PR DESCRIPTION
…_rule

# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
