### PR TITLE
- consumption budget requires /subscriptions/ prefix

### DIFF
--- a/modules/consumption_budget/subscription/subscription_budget.tf
+++ b/modules/consumption_budget/subscription/subscription_budget.tf
@@ -10,11 +10,11 @@ resource "azurecaf_name" "this_name" {
 
 resource "azurerm_consumption_budget_subscription" "this" {
   name = azurecaf_name.this_name.result
-  subscription_id = coalesce(
+  subscription_id = "/subscriptions/${coalesce(
     try(var.settings.subscription.id, null),
     try(var.local_combined_resources["subscriptions"][try(var.settings.subscription.lz_key, var.client_config.landingzone_key)][var.settings.subscription.key].subscription_id, null),
     var.client_config.subscription_id
-  )
+  )}"
 
   amount     = var.settings.amount
   time_grain = var.settings.time_grain


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

consumption budget requires subscription id in the format of resource id (/subscriptions/<subscription-id>)

## Does this introduce a breaking change

- [x] YES
- [ ] NO

existing references in the tfvars with /subscriptions/<subscription-id> must be replaced by subscription-id

## Testing

<!-- Instructions for testing and validation of your code -->
