### PR TITLE
feature: servicebus topic name passthrough

### DIFF
--- a/modules/messaging/servicebus/queue/queue.tf
+++ b/modules/messaging/servicebus/queue/queue.tf
@@ -4,7 +4,7 @@ resource "azurecaf_name" "queue" {
   prefixes      = var.global_settings.prefixes
   random_length = var.global_settings.random_length
   clean_input   = true
-  passthrough   = var.global_settings.passthrough
+  passthrough = try(var.settings.passthrough, false) ? var.settings.passthrough : var.global_settings.passthrough
   use_slug      = var.global_settings.use_slug
 }
 

--- a/modules/messaging/servicebus/queue/queue.tf
+++ b/modules/messaging/servicebus/queue/queue.tf
@@ -4,7 +4,7 @@ resource "azurecaf_name" "queue" {
   prefixes      = var.global_settings.prefixes
   random_length = var.global_settings.random_length
   clean_input   = true
-  passthrough = try(var.settings.passthrough, false) ? var.settings.passthrough : var.global_settings.passthrough
+  passthrough   = try(var.settings.passthrough, false) ? var.settings.passthrough : var.global_settings.passthrough
   use_slug      = var.global_settings.use_slug
 }
 

--- a/modules/messaging/servicebus/topic/subscription/subscription.tf
+++ b/modules/messaging/servicebus/topic/subscription/subscription.tf
@@ -4,7 +4,7 @@ resource "azurecaf_name" "servicebus_subscription" {
   prefixes      = var.global_settings.prefixes
   random_length = var.global_settings.random_length
   clean_input   = true
-  passthrough   = var.global_settings.passthrough
+  passthrough = try(var.settings.passthrough, false) ? var.settings.passthrough : var.global_settings.passthrough
   use_slug      = var.global_settings.use_slug
 }
 

--- a/modules/messaging/servicebus/topic/subscription/subscription.tf
+++ b/modules/messaging/servicebus/topic/subscription/subscription.tf
@@ -4,7 +4,7 @@ resource "azurecaf_name" "servicebus_subscription" {
   prefixes      = var.global_settings.prefixes
   random_length = var.global_settings.random_length
   clean_input   = true
-  passthrough = try(var.settings.passthrough, false) ? var.settings.passthrough : var.global_settings.passthrough
+  passthrough   = try(var.settings.passthrough, false) ? var.settings.passthrough : var.global_settings.passthrough
   use_slug      = var.global_settings.use_slug
 }
 

--- a/modules/messaging/servicebus/topic/topic.tf
+++ b/modules/messaging/servicebus/topic/topic.tf
@@ -4,7 +4,7 @@ resource "azurecaf_name" "topic" {
   prefixes      = var.global_settings.prefixes
   random_length = var.global_settings.random_length
   clean_input   = true
-  passthrough = try(var.settings.passthrough, false) ? var.settings.passthrough : var.global_settings.passthrough
+  passthrough   = try(var.settings.passthrough, false) ? var.settings.passthrough : var.global_settings.passthrough
   use_slug      = var.global_settings.use_slug
 }
 

--- a/modules/messaging/servicebus/topic/topic.tf
+++ b/modules/messaging/servicebus/topic/topic.tf
@@ -4,7 +4,7 @@ resource "azurecaf_name" "topic" {
   prefixes      = var.global_settings.prefixes
   random_length = var.global_settings.random_length
   clean_input   = true
-  passthrough   = var.global_settings.passthrough
+  passthrough = try(var.settings.passthough, false) ? var.settings.passthough : var.global_settings.passthrough
   use_slug      = var.global_settings.use_slug
 }
 

--- a/modules/messaging/servicebus/topic/topic.tf
+++ b/modules/messaging/servicebus/topic/topic.tf
@@ -4,7 +4,7 @@ resource "azurecaf_name" "topic" {
   prefixes      = var.global_settings.prefixes
   random_length = var.global_settings.random_length
   clean_input   = true
-  passthrough = try(var.settings.passthough, false) ? var.settings.passthough : var.global_settings.passthrough
+  passthrough = try(var.settings.passthrough, false) ? var.settings.passthrough : var.global_settings.passthrough
   use_slug      = var.global_settings.use_slug
 }
 


### PR DESCRIPTION
- topic needs a predictable name for external reference
- added an option in resource settings to make name passthrough

# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/1917)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

service bus topic needs a predictable name. name passthrough is currently possible in landing zone scope, and the PR supports this change at individual resource level. 

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
