### PR TITLE
feat: azure ad pre_authorized application

### DIFF
--- a/examples/azuread/109-azuread-application-with-authorized-client/confifgurations.tfvars
+++ b/examples/azuread/109-azuread-application-with-authorized-client/confifgurations.tfvars
@@ -1,0 +1,77 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "uksouth"
+  }
+  random_length = 5
+}
+
+
+azuread_apps = {
+  test_client = {
+    useprefix                      = true
+    application_name               = "test-client"
+    sign_in_audience               = "AzureADMyOrg"
+    prevent_duplicate_names        = true
+    fallback_public_client_enabled = true
+
+    single_page_application = {
+      redirect_uris = [
+        "https://uri1.aztfmod.github.io/",
+        "https://uri2.aztfmod.github.io/"
+      ]
+    }
+  }
+}
+
+
+azuread_applications = {
+  test_client_v1 = {
+    useprefix        = true
+    application_name = "test-client-v1"
+    public_client    = true
+
+    single_page_application = {
+      redirect_uris = [
+        "https://uri1.aztfmod.github.io/",
+        "https://uri2.aztfmod.github.io/"
+      ]
+    }
+
+    api = {
+      mapped_claims_enabled          = true
+      requested_access_token_version = 2
+
+      oauth2_permission_scopes = [
+        {
+          admin_consent_description  = "Allow to administer app."
+          admin_consent_display_name = "Administer app"
+          enabled                    = true
+          # Generate UUID: uuidgen | tr "[:upper:]" "[:lower:]"
+          id    = "d4c3605a-b327-35c5-f04d-77f7fcdd4995"
+          type  = "Admin"
+          value = "app"
+        },
+        {
+          admin_consent_description  = "Allow to administer app2."
+          admin_consent_display_name = "Administer app2"
+          enabled                    = true
+          type  = "Admin"
+          value = "app2"
+        }
+      ]
+
+      pre_authorized_clients = {
+        azure_powershell = {
+          authorized_client_id = "1950a258-227b-4e31-a9cf-717495945fc2"
+          selected_scopes       = ["app", "app2"]
+        }
+        azure_cli = {
+          authorized_client_id = "04b07795-8ddb-461a-bbee-02f9e1bf7b46"
+          selected_scopes       = ["app2"]
+        }
+      }
+
+    }
+  }
+}

--- a/locals.tf
+++ b/locals.tf
@@ -207,6 +207,8 @@ locals {
     signalr_services            = local.combined_objects_signalr_services
     storage_accounts            = local.combined_objects_storage_accounts
     networking                  = local.combined_objects_networking
+    azuread_applications        = local.combined_objects_azuread_applications
+    cosmosdb_sql_databases      = local.combined_objects_cosmosdb_sql_databases
   }
 
   dynamic_app_config_combined_objects = {

--- a/modules/azuread/applications_v1/azuread_application.tf
+++ b/modules/azuread/applications_v1/azuread_application.tf
@@ -138,3 +138,15 @@ resource "random_uuid" "oauth2_permission_scopes" {
     if try(value.id, null) == null
   }
 }
+
+resource "azuread_application_pre_authorized" "pre_authorized_client" {
+  for_each = try(var.settings.api.pre_authorized_clients, {})
+
+  application_id       = azuread_application.app.id
+  authorized_client_id = each.value.authorized_client_id
+  permission_ids = [
+    for key, scope in try(var.settings.api.oauth2_permission_scopes, {}) :
+    try(scope.id, random_uuid.oauth2_permission_scopes[key].id)
+    if contains(each.value.selected_scopes, scope.value)
+  ]
+}


### PR DESCRIPTION
feat: azure ad pre_authorized application

- added azuread_application_pre_authorized resource
- included additional input references in app service dynamic secrets

## PR Checklist

- [x] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Azure AD Pre authorized application to allow azure powershell and cli used by IPAM service to authenticate.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Testing

example provided
