### PR TITLE
FC-1285: Allow workloads on CAF level 4 to create Entra ID groups

### DIFF
--- a/azuread_custom_directory_roles.tf
+++ b/azuread_custom_directory_roles.tf
@@ -1,0 +1,72 @@
+//testcase
+locals {
+  azuread_custom_directory_roles = {
+    group_self_service = { // role key
+      display_name = "group-self-service"
+      description = "room for notes"
+      enabled      = "true"
+      version      = "1.0"
+      permissions = {
+        allowed_resource_actions =        [
+          "microsoft.directory/groups/allProperties/read",
+          "microsoft.directory/groups/members/read",
+          "microsoft.directory/groups.security/createAsOwner",
+          "microsoft.directory/groups/delete",
+          "microsoft.directory/groups.security/allProperties/update",
+          "microsoft.directory/groups/members/update"
+        ]
+      #[
+      #  "microsoft.directory/applications/basic/update",
+      #  "microsoft.directory/applications/create",
+      #  "microsoft.directory/applications/standard/read",
+      #]
+
+
+      }
+    }
+  }
+  azuread_directory_role_assignments = {
+    custom_azuread_roles = {
+      group_self_service = {
+        //lz_key = ""
+        azuread_groups = {
+          keys = ["caf_group_self_service"]
+          //lz_key = ""
+        }
+      }
+    }
+  }
+}
+
+module "azuread_custom_directory_roles" {
+  source   = "./modules/azuread/custom_directory_roles"
+  for_each = local.azuread_custom_directory_roles
+
+  global_settings = local.global_settings
+  tenant_id       = local.client_config.tenant_id
+  client_config   = local.client_config
+  settings      = each.value
+}
+
+output "azuread_custom_directory_roles" {
+  value = module.azuread_custom_directory_roles
+}
+
+
+module "azuread_directory_role_assignments" {
+  source   = "./modules/azuread/directory_role_assignment"
+  for_each = local.azuread_directory_role_assignments
+
+  global_settings = local.global_settings
+  tenant_id       = local.client_config.tenant_id
+  client_config   = local.client_config
+  remote_objects = {
+    azuread_custom_directory_roles = local.combined_objects_azuread_custom_directory_roles
+    azuread_groups = local.combined_objects_azuread_groups
+    azuread_apps = local.combined_objects_azuread_apps
+  }
+  settings      = each.value
+}
+output "azuread_directory_role_assignments" {
+  value = module.azuread_directory_role_assignments
+}

--- a/locals.combined_objects.tf
+++ b/locals.combined_objects.tf
@@ -28,6 +28,7 @@ locals {
   combined_objects_azuread_administrative_units = merge(tomap({ (local.client_config.landingzone_key) = module.azuread_administrative_unit }), try(var.remote_objects.administrative_units, {}))
   combined_objects_azuread_applications = merge(tomap({ (local.client_config.landingzone_key) = module.azuread_applications_v1 }), try(var.remote_objects.azuread_applications, {}))
   combined_objects_azuread_apps = merge(tomap({ (local.client_config.landingzone_key) = module.azuread_applications }), try(var.remote_objects.azuread_apps, {}))
+  combined_objects_azuread_custom_directory_roles = merge(tomap({ (local.client_config.landingzone_key) = module.azuread_custom_directory_roles }), try(var.remote_objects.azuread_custom_directory_roles, {}))
   combined_objects_azuread_groups = merge(tomap({ (local.client_config.landingzone_key) = merge(module.azuread_groups, try(var.data_sources.azuread_groups, {})) }), try(var.remote_objects.azuread_groups, {}))
   combined_objects_azuread_service_principal_passwords = merge(tomap({ (local.client_config.landingzone_key) = module.azuread_service_principal_passwords }), try(var.remote_objects.azuread_service_principal_passwords, {}))
   combined_objects_azuread_service_principals = merge(tomap({ (local.client_config.landingzone_key) = module.azuread_service_principals }), try(var.remote_objects.azuread_service_principals, {}), try(var.data_sources.azuread_service_principals, {}))

--- a/modules/azuread/custom_directory_roles/custom_directory_roles.tf
+++ b/modules/azuread/custom_directory_roles/custom_directory_roles.tf
@@ -1,0 +1,17 @@
+
+resource "azuread_custom_directory_role" "directory_role" {
+  //todo: implement CAF Name Resource
+  display_name = var.settings.display_name
+  description  = try(var.settings.description, "none")
+  enabled      = var.settings.enabled
+  version      = var.settings.version
+
+  dynamic "permissions" {
+    for_each = var.settings.permissions
+    content {
+      allowed_resource_actions = permissions.value
+    }
+  }
+}
+
+# Condition https://learn.microsoft.com/en-us/graph/api/resources/unifiedrolepermission?view=graph-rest-1.0

--- a/modules/azuread/custom_directory_roles/variables.tf
+++ b/modules/azuread/custom_directory_roles/variables.tf
@@ -1,0 +1,17 @@
+variable "global_settings" {
+  description = "Global settings object (see module README.md)"
+}
+variable "tenant_id" {
+  description = "The tenant ID of the Azure AD environment where to create the groups."
+  type        = string
+}
+variable "client_config" {
+  description = "Client configuration object (see module README.md)."
+}
+variable "remote_objects" {
+  description = "(Required) Specifies the supported Azure location where to create the resource. Changing this forces a new resource to be created."
+  default     = {}
+}
+variable "settings" {
+  default     = {}
+}

--- a/modules/azuread/directory_role_assignment/directory_role_assignment.tf
+++ b/modules/azuread/directory_role_assignment/directory_role_assignment.tf
@@ -1,0 +1,19 @@
+#resource "azuread_directory_role_assignment" "directory_role_assignment" {
+#  role_id             = azuread_custom_directory_role.example.object_id
+#  principal_object_id = data.azuread_user.example.object_id
+#}
+#
+resource "null_resource" "debug" {
+  # Changes to any instance of the cluster requires re-provisioning
+  triggers = {
+    cluster_instance_ids = jsonencode(local.custom_role_id)
+  }
+}
+locals {
+  custom_role_id = {for role, config in try(var.settings.custom_azuread_roles, {}) :
+    role => var.remote_objects["azuread_custom_directory_roles"][try(config.lz_key, var.client_config.landingzone_key)][role].id
+  }  
+}
+output "custom_role_id" {
+  value = local.custom_role_id
+}

--- a/modules/azuread/directory_role_assignment/variables.tf
+++ b/modules/azuread/directory_role_assignment/variables.tf
@@ -1,0 +1,17 @@
+variable "global_settings" {
+  description = "Global settings object (see module README.md)"
+}
+variable "tenant_id" {
+  description = "The tenant ID of the Azure AD environment where to create the groups."
+  type        = string
+}
+variable "client_config" {
+  description = "Client configuration object (see module README.md)."
+}
+variable "remote_objects" {
+  description = "(Required) Specifies the supported Azure location where to create the resource. Changing this forces a new resource to be created."
+  default     = {}
+}
+variable "settings" {
+  default     = {}
+}


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
