### PR TITLE
support policy id with frontdoor

### DIFF
--- a/modules/networking/front_door/front_door.tf
+++ b/modules/networking/front_door/front_door.tf
@@ -123,7 +123,7 @@ resource "azurerm_frontdoor" "frontdoor" {
       host_name                               = try(frontend_endpoint.value.host_name, format("%s.azurefd.net", azurecaf_name.frontdoor.result))
       session_affinity_enabled                = try(frontend_endpoint.value.session_affinity_enabled, null)
       session_affinity_ttl_seconds            = try(frontend_endpoint.value.session_affinity_ttl_seconds, null)
-      web_application_firewall_policy_link_id = try(frontend_endpoint.value.front_door_waf_policy.key, null) == null ? null : var.front_door_waf_policies[try(frontend_endpoint.value.front_door_waf_policy.lz_key, var.client_config.landingzone_key)][frontend_endpoint.value.front_door_waf_policy.key].id
+      web_application_firewall_policy_link_id = try(frontend_endpoint.value.web_application_firewall_policy_link_id, var.front_door_waf_policies[try(frontend_endpoint.value.front_door_waf_policy.lz_key, var.client_config.landingzone_key)][frontend_endpoint.value.front_door_waf_policy.key].id, null)
     }
   }
 }


### PR DESCRIPTION
## Description

support resource id with frontdoor endpoint policy

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Testing

    frontend_endpoints = {
      frontend = {
        name                              = "<name>"
        custom_https_provisioning_enabled = false
        web_application_firewall_policy_link_id = "<policy-id>"
      }
