### PR TITLE
ad app role assignment dependency added

### DIFF
--- a/azuread_app_role_assignment.tf
+++ b/azuread_app_role_assignment.tf
@@ -1,6 +1,7 @@
 module "azuread_app_role_assignments" {
   source     = "./modules/azuread/azuread_app_role_assignments"
   for_each   = local.azuread.azuread_app_role_assignments
+  depends_on = [module.azuread_service_principals]
 
   resource_object_id      = can(each.value.resource_object.id) ? each.value.resource_object.id : local.combined_objects_azuread_service_principals[try(each.value.resource_object.lz_key, local.client_config.landingzone_key)][each.value.resource_object.key].object_id
   client_config           = local.client_config


### PR DESCRIPTION
## PR Checklist

## Description

Azure AD app role assignment requires azure ad service principal to exists. Implicit dependency does not help. Explicit module dependency added when all resources are created at same level

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Testing

No changes to user code.
