### PR TITLE
feat: storage cmk support

### DIFF
--- a/modules/storage_account/storage_account.tf
+++ b/modules/storage_account/storage_account.tf
@@ -18,12 +18,12 @@ resource "azurecaf_name" "stg" {
 # Ref : https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account
 
 resource "azurerm_storage_account" "stg" {
-  name                              = azurecaf_name.stg.result
-  account_tier                      = try(var.storage_account.account_tier, "Standard")
-  account_replication_type          = try(var.storage_account.account_replication_type, "LRS")
-  account_kind                      = try(var.storage_account.account_kind, "StorageV2")
-  access_tier                       = contains(["BlobStorage", "FileStorage", "StorageV2"], try(var.storage_account.account_kind, "StorageV2")) ? try(var.storage_account.access_tier, "Hot") : null
-  allow_nested_items_to_be_public   = try(var.storage_account.allow_nested_items_to_be_public, var.storage_account.allow_blob_public_access, false)
+  name                            = azurecaf_name.stg.result
+  account_tier                    = try(var.storage_account.account_tier, "Standard")
+  account_replication_type        = try(var.storage_account.account_replication_type, "LRS")
+  account_kind                    = try(var.storage_account.account_kind, "StorageV2")
+  access_tier                     = contains(["BlobStorage", "FileStorage", "StorageV2"], try(var.storage_account.account_kind, "StorageV2")) ? try(var.storage_account.access_tier, "Hot") : null
+  allow_nested_items_to_be_public = try(var.storage_account.allow_nested_items_to_be_public, var.storage_account.allow_blob_public_access, false)
   # Falsely defaults to true in this version 3.114.0 https://github.com/hashicorp/terraform-provider-azurerm/pull/26962
   cross_tenant_replication_enabled  = try(var.storage_account.cross_tenant_replication_enabled, false)
   edge_zone                         = try(var.storage_account.edge_zone, null)
@@ -251,7 +251,7 @@ resource "azurerm_storage_account" "stg" {
 
   lifecycle {
     ignore_changes = [
-      location, resource_group_name
+      location, resource_group_name, customer_managed_key
     ]
   }
 }

--- a/storage_accounts.tf
+++ b/storage_accounts.tf
@@ -38,10 +38,11 @@ resource "azurerm_storage_account_customer_managed_key" "cmk" {
     if can(value.customer_managed_key)
   }
 
-  storage_account_id = module.storage_accounts[each.key].id
-  key_vault_id       = local.combined_objects_keyvaults[try(each.value.customer_managed_key.lz_key, local.client_config.landingzone_key)][each.value.customer_managed_key.keyvault_key].id
-  key_name           = can(each.value.customer_managed_key.key_name) ? each.value.customer_managed_key.key_name : local.combined_objects_keyvault_keys[try(each.value.customer_managed_key.lz_key, local.client_config.landingzone_key)][each.value.customer_managed_key.keyvault_key_key].name
-  key_version        = try(each.value.customer_managed_key.key_version, null)
+  storage_account_id        = module.storage_accounts[each.key].id
+  key_vault_id              = local.combined_objects_keyvaults[try(each.value.customer_managed_key.lz_key, local.client_config.landingzone_key)][each.value.customer_managed_key.keyvault_key].id
+  key_name                  = can(each.value.customer_managed_key.key_name) ? each.value.customer_managed_key.key_name : local.combined_objects_keyvault_keys[try(each.value.customer_managed_key.lz_key, local.client_config.landingzone_key)][each.value.customer_managed_key.keyvault_key_key].name
+  key_version               = try(each.value.customer_managed_key.key_version, null)
+  user_assigned_identity_id = can(each.value.customer_managed_key.managed_identity) ? coalesce(try(each.value.customer_managed_key.managed_identity.id, null), try(local.combined_objects_managed_identities[try(each.value.customer_managed_key.managed_identity.lz_key, local.client_config.landingzone_key)][each.value.customer_managed_key.managed_identity.key].id, null)) : null
 }
 
 module "encryption_scopes" {


### PR DESCRIPTION
## Description

fix storage account cmk. storage account does not ignore cmk block. However, this must be done as cmk is managed with a dedicated terraform resource.

added user assigned identity support for cmk

## Does this introduce a breaking change

- [ ] YES
- [x] NO