### PR TITLE
- support security provider with routing intent

### DIFF
--- a/modules/networking/virtual_wan/virtual_hub/output.tf
+++ b/modules/networking/virtual_wan/virtual_hub/output.tf
@@ -43,3 +43,8 @@ output "default_route_table_id" {
   description = "Resource ID of the Virtual Hub Default Route Table"
   value       = azurerm_virtual_hub.vwan_hub.default_route_table_id
 }
+
+output "security_partner_provider" {
+  description = "Security Partner Provider Configuration"
+  value       = azurerm_virtual_hub_security_partner_provider.spp
+}

--- a/networking_virtual_hub_routing_intent.tf
+++ b/networking_virtual_hub_routing_intent.tf
@@ -10,7 +10,9 @@ resource "azurerm_virtual_hub_routing_intent" "this" {
       destinations = routing_policy.value.destinations
       next_hop = coalesce(
         try(routing_policy.value.next_hop.id, routing_policy.value.next_hop_id, null),
-        try(local.combined_objects_azurerm_firewalls[try(routing_policy.value.next_hop.lz_key, local.client_config.landingzone_key)][routing_policy.value.next_hop.key].id)
+        try(local.combined_objects_azurerm_firewalls[try(routing_policy.value.next_hop.lz_key, local.client_config.landingzone_key)][routing_policy.value.next_hop.firewall_key].id, null),
+        try(local.combined_objects_virtual_wans[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.virtual_wan_key].virtual_hubs[routing_policy.value.next_hop.virtual_hub_key].security_partner_provider[routing_policy.value.next_hop.security_partner_provider_key].id, null),
+        try(local.combined_objects_virtual_hubs[try(each.value.virtual_hub.lz_key, local.client_config.landingzone_key)][each.value.virtual_hub.key].security_partner_provider[routing_policy.value.next_hop.security_partner_provider_key].id, null)
       )
     }
   }


### PR DESCRIPTION
## Description

hub routing intent now support security provider as next hop.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Testing

```
virtual_hub_routing_intents = {
  key = {
    name = ""
    virtual_hub = {
      lz_key = ""
      key    = ""
    }
    routing_policy = {
      private_traffic_policy = {
        name = "PrivateTrafficPolicy"
        next_hop = {
          firewall_key    = ""
        }
        destinations = ["PrivateTraffic"]
      }
      internet_traffic_policy = {
        name = "InternetTrafficPolicy"
        next_hop = {
          security_partner_provider_key = ""
        }
        destinations = ["Internet"]
      }
    }
  }
}
```
