### PR TITLE
feature: optionally ignore private endpoint dns change

### DIFF
--- a/modules/analytics/databricks_workspace/private_endpoint.tf
+++ b/modules/analytics/databricks_workspace/private_endpoint.tf
@@ -1,6 +1,8 @@
 module "private_endpoint" {
   source   = "../../networking/private_endpoint"
-  for_each = var.private_endpoints
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   tags                = local.tags
   base_tags           = var.base_tags
@@ -9,6 +11,24 @@ module "private_endpoint" {
   location            = var.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
   name                = each.value.name
   private_dns         = var.private_dns
+  resource_group_name = var.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].name
+  resource_id         = azurerm_databricks_workspace.ws.id
+  settings            = each.value
+  subnet_id           = can(each.value.subnet_id) ? each.value.subnet_id : var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+}
+
+module "private_endpoint_v1" {
+  source   = "../../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
+
+  tags                = local.tags
+  base_tags           = var.base_tags
+  client_config       = var.client_config
+  global_settings     = var.global_settings
+  location            = var.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
+  name                = each.value.name
   resource_group_name = var.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].name
   resource_id         = azurerm_databricks_workspace.ws.id
   settings            = each.value

--- a/modules/analytics/synapse/private_endpoints.tf
+++ b/modules/analytics/synapse/private_endpoints.tf
@@ -1,6 +1,8 @@
 module "private_endpoint" {
   source   = "../../networking/private_endpoint"
-  for_each = var.private_endpoints
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   resource_id     = azurerm_synapse_workspace.ws.id
   name            = each.value.name
@@ -11,5 +13,22 @@ module "private_endpoint" {
   tags            = local.tags
   base_tags       = var.base_tags
   private_dns     = var.private_dns
+  client_config   = var.client_config
+}
+
+module "private_endpoint_v1" {
+  source   = "../../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
+
+  resource_id     = azurerm_synapse_workspace.ws.id
+  name            = each.value.name
+  location        = local.location
+  subnet_id       = can(each.value.subnet_id) ? each.value.subnet_id : var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+  settings        = each.value
+  global_settings = var.global_settings
+  tags            = local.tags
+  base_tags       = var.base_tags
   client_config   = var.client_config
 }

--- a/modules/automation/private_endpoints.tf
+++ b/modules/automation/private_endpoints.tf
@@ -4,7 +4,9 @@
 
 module "private_endpoint" {
   source   = "../networking/private_endpoint"
-  for_each = var.private_endpoints
+  for_each = {
+    for k,v in lookup(var.settings, "private_endpoints", {}) : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   resource_id         = azurerm_automation_account.auto_account.id
   name                = each.value.name
@@ -16,5 +18,23 @@ module "private_endpoint" {
   tags                = local.tags
   base_tags           = var.base_tags
   private_dns         = var.remote_objects.private_dns
+  client_config       = var.client_config
+}
+
+module "private_endpoint_v1" {
+  source   = "../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in lookup(var.settings, "private_endpoints", {}) : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
+
+  resource_id         = azurerm_automation_account.auto_account.id
+  name                = each.value.name
+  location            = local.location
+  resource_group_name = local.resource_group_name
+  subnet_id           = can(each.value.subnet_id) ? each.value.subnet_id : var.remote_objects.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+  settings            = each.value
+  global_settings     = var.global_settings
+  tags                = local.tags
+  base_tags           = var.base_tags
   client_config       = var.client_config
 }

--- a/modules/cognitive_services/cognitive_services_account/private_endpoints.tf
+++ b/modules/cognitive_services/cognitive_services_account/private_endpoints.tf
@@ -4,7 +4,9 @@
 
 module "private_endpoint" {
   source   = "../../networking/private_endpoint"
-  for_each = var.private_endpoints
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   resource_id         = azurerm_cognitive_account.service.id
   name                = each.value.name
@@ -16,5 +18,23 @@ module "private_endpoint" {
   base_tags           = var.base_tags
   tags                = local.tags
   private_dns         = var.private_dns
+  client_config       = var.client_config
+}
+
+module "private_endpoint_v1" {
+  source   = "../../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
+
+  resource_id         = azurerm_cognitive_account.service.id
+  name                = each.value.name
+  location            = var.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
+  resource_group_name = var.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].name
+  subnet_id           = can(each.value.subnet_id) ? each.value.subnet_id : var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+  settings            = each.value
+  global_settings     = var.global_settings
+  base_tags           = var.base_tags
+  tags                = local.tags
   client_config       = var.client_config
 }

--- a/modules/compute/aks/private_endpoint.tf
+++ b/modules/compute/aks/private_endpoint.tf
@@ -1,6 +1,8 @@
 module "private_endpoint" {
   source   = "../../networking/private_endpoint"
-  for_each = var.private_endpoints
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   base_tags           = var.global_settings.inherit_tags
   client_config       = var.client_config
@@ -8,6 +10,23 @@ module "private_endpoint" {
   location            = var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][try(each.value.vnet.key, each.value.vnet_key)].location
   name                = each.value.name
   private_dns         = var.private_dns
+  resource_group_name = local.resource_group_name
+  resource_id         = azurerm_kubernetes_cluster.aks.id
+  settings            = each.value
+  subnet_id           = can(each.value.subnet_id) ? each.value.subnet_id : var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+}
+
+module "private_endpoint_v1" {
+  source   = "../../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in try(var.private_endpoints, var.private_endpoints) : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
+
+  base_tags           = var.global_settings.inherit_tags
+  client_config       = var.client_config
+  global_settings     = var.global_settings
+  location            = var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][try(each.value.vnet.key, each.value.vnet_key)].location
+  name                = each.value.name
   resource_group_name = local.resource_group_name
   resource_id         = azurerm_kubernetes_cluster.aks.id
   settings            = each.value

--- a/modules/compute/batch/batch_account/private_endpoint.tf
+++ b/modules/compute/batch/batch_account/private_endpoint.tf
@@ -1,6 +1,8 @@
 module "private_endpoint" {
   source   = "../../../networking/private_endpoint"
-  for_each = var.private_endpoints
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   tags                = local.tags
   base_tags           = var.base_tags
@@ -9,6 +11,24 @@ module "private_endpoint" {
   location            = local.location
   name                = each.value.name
   private_dns         = var.remote_objects.private_dns
+  resource_group_name = var.remote_objects.resource_groups[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.resource_group_key].name
+  resource_id         = azurerm_batch_account.account.id
+  settings            = each.value
+  subnet_id           = can(each.value.subnet_id) ? each.value.subnet_id : var.remote_objects.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+}
+
+module "private_endpoint_v1" {
+  source   = "../../../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
+
+  tags                = local.tags
+  base_tags           = var.base_tags
+  client_config       = var.client_config
+  global_settings     = var.global_settings
+  location            = local.location
+  name                = each.value.name
   resource_group_name = var.remote_objects.resource_groups[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.resource_group_key].name
   resource_id         = azurerm_batch_account.account.id
   settings            = each.value

--- a/modules/compute/container_registry/private_endpoint.tf
+++ b/modules/compute/container_registry/private_endpoint.tf
@@ -1,7 +1,9 @@
 
 module "private_endpoint" {
   source   = "../../networking/private_endpoint"
-  for_each = var.private_endpoints
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   tags                = local.tags
   base_tags           = var.base_tags
@@ -10,6 +12,24 @@ module "private_endpoint" {
   location            = var.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
   name                = each.value.name
   private_dns         = var.private_dns
+  resource_group_name = var.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].name
+  resource_id         = azurerm_container_registry.acr.id
+  settings            = each.value
+  subnet_id           = can(each.value.subnet_id) ? each.value.subnet_id : var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+}
+
+module "private_endpoint_v1" {
+  source   = "../../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
+
+  tags                = local.tags
+  base_tags           = var.base_tags
+  client_config       = var.client_config
+  global_settings     = var.global_settings
+  location            = var.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
+  name                = each.value.name
   resource_group_name = var.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].name
   resource_id         = azurerm_container_registry.acr.id
   settings            = each.value

--- a/modules/data_factory/data_factory/private_endpoints.tf
+++ b/modules/data_factory/data_factory/private_endpoints.tf
@@ -14,3 +14,20 @@ module "private_endpoint" {
   private_dns         = var.remote_objects.private_dns
   client_config       = var.client_config
 }
+
+module "private_endpoint_v1" {
+  source   = "../../networking/private_endpoint_v1"
+  for_each = var.remote_objects.private_endpoints
+
+  resource_id         = azurerm_data_factory.df.id
+  name                = each.value.name
+  resource_group_name = var.remote_objects.resource_groups[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.resource_group_key].name
+  location            = var.location
+  subnet_id           = can(each.value.subnet_id) ? each.value.subnet_id : var.remote_objects.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+  settings            = each.value
+  global_settings     = var.global_settings
+  tags                = local.tags
+  base_tags           = var.base_tags
+  private_dns         = var.remote_objects.private_dns
+  client_config       = var.client_config
+}

--- a/modules/data_factory/data_factory/private_endpoints.tf
+++ b/modules/data_factory/data_factory/private_endpoints.tf
@@ -11,7 +11,6 @@ module "private_endpoint" {
   global_settings     = var.global_settings
   tags                = local.tags
   base_tags           = var.base_tags
-  private_dns         = var.remote_objects.private_dns
   client_config       = var.client_config
 }
 
@@ -28,6 +27,5 @@ module "private_endpoint_v1" {
   global_settings     = var.global_settings
   tags                = local.tags
   base_tags           = var.base_tags
-  private_dns         = var.remote_objects.private_dns
   client_config       = var.client_config
 }

--- a/modules/databases/app_config/private_endpoints.tf
+++ b/modules/databases/app_config/private_endpoints.tf
@@ -4,7 +4,9 @@
 
 module "private_endpoint" {
   source   = "../../networking/private_endpoint"
-  for_each = lookup(var.settings, "private_endpoints", {})
+  for_each = {
+    for k,v in lookup(var.settings, "private_endpoints", {}) : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   resource_id         = azurerm_app_configuration.config.id
   name                = each.value.name
@@ -16,5 +18,23 @@ module "private_endpoint" {
   tags                = local.tags
   base_tags           = var.base_tags
   private_dns         = var.private_dns
+  client_config       = var.client_config
+}
+
+module "private_endpoint_v1" {
+  source   = "../../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in lookup(var.settings, "private_endpoints", {}) : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
+
+  resource_id         = azurerm_app_configuration.config.id
+  name                = each.value.name
+  location            = local.location
+  resource_group_name = local.resource_group_name
+  subnet_id           = can(each.value.subnet_id) ? each.value.subnet_id : var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+  settings            = each.value
+  global_settings     = var.global_settings
+  tags                = local.tags
+  base_tags           = var.base_tags
   client_config       = var.client_config
 }

--- a/modules/databases/cosmos_dbs/private_endpoints.tf
+++ b/modules/databases/cosmos_dbs/private_endpoints.tf
@@ -6,7 +6,9 @@
 
 module "private_endpoint" {
   source   = "../../networking/private_endpoint"
-  for_each = var.private_endpoints
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   resource_id         = azurerm_cosmosdb_account.cosmos_account.id
   name                = each.value.name
@@ -18,5 +20,23 @@ module "private_endpoint" {
   base_tags           = var.base_tags
   tags                = local.tags
   private_dns         = var.private_dns
+  client_config       = var.client_config
+}
+
+module "private_endpoint_v1" {
+  source   = "../../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
+
+  resource_id         = azurerm_cosmosdb_account.cosmos_account.id
+  name                = each.value.name
+  location            = var.resource_groups[each.value.resource_group_key].location
+  resource_group_name = var.resource_groups[each.value.resource_group_key].name
+  subnet_id           = can(each.value.subnet_id) ? each.value.subnet_id : var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+  settings            = each.value
+  global_settings     = var.global_settings
+  base_tags           = var.base_tags
+  tags                = local.tags
   client_config       = var.client_config
 }

--- a/modules/databases/data_explorer/kusto_clusters/private_endpoint.tf
+++ b/modules/databases/data_explorer/kusto_clusters/private_endpoint.tf
@@ -1,6 +1,8 @@
 module "private_endpoint" {
   source   = "../../../networking/private_endpoint"
-  for_each = try(var.private_endpoints, {})
+  for_each = {
+    for k,v in try(var.private_endpoints, {}) : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   resource_id         = azurerm_kusto_cluster.kusto.id
   name                = each.value.name
@@ -12,5 +14,23 @@ module "private_endpoint" {
   base_tags           = var.global_settings.inherit_tags
   tags                = local.tags
   private_dns         = var.combined_resources.private_dns
+  client_config       = var.client_config
+}
+
+module "private_endpoint_v1" {
+  source   = "../../../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in try(var.private_endpoints, {}) : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
+
+  resource_id         = azurerm_kusto_cluster.kusto.id
+  name                = each.value.name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  subnet_id           = can(each.value.subnet_id) ? each.value.subnet_id : var.combined_resources.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+  settings            = each.value
+  global_settings     = var.global_settings
+  base_tags           = var.global_settings.inherit_tags
+  tags                = local.tags
   client_config       = var.client_config
 }

--- a/modules/databases/mariadb_server/private_endpoints.tf
+++ b/modules/databases/mariadb_server/private_endpoints.tf
@@ -6,7 +6,9 @@
 
 module "private_endpoint" {
   source   = "../../networking/private_endpoint"
-  for_each = try(var.private_endpoints, {})
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   resource_id         = azurerm_mariadb_server.mariadb.id
   name                = each.value.name
@@ -21,10 +23,11 @@ module "private_endpoint" {
   client_config       = var.client_config
 }
 
-module "private_endpoint" {
-  source   = "../../networking/private_endpoint"
-  for_each = try(var.private_endpoints, {})
-
+module "private_endpoint_v1" {
+  source   = "../../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
   resource_id         = azurerm_mariadb_server.mariadb.id
   name                = each.value.name
   location            = local.location
@@ -34,6 +37,5 @@ module "private_endpoint" {
   global_settings     = var.global_settings
   tags                = local.tags
   base_tags           = var.base_tags
-  private_dns         = var.private_dns
   client_config       = var.client_config
 }

--- a/modules/databases/mariadb_server/private_endpoints.tf
+++ b/modules/databases/mariadb_server/private_endpoints.tf
@@ -20,3 +20,20 @@ module "private_endpoint" {
   private_dns         = var.private_dns
   client_config       = var.client_config
 }
+
+module "private_endpoint" {
+  source   = "../../networking/private_endpoint"
+  for_each = try(var.private_endpoints, {})
+
+  resource_id         = azurerm_mariadb_server.mariadb.id
+  name                = each.value.name
+  location            = local.location
+  resource_group_name = local.resource_group_name
+  subnet_id           = can(each.value.subnet_id) ? each.value.subnet_id : var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+  settings            = each.value
+  global_settings     = var.global_settings
+  tags                = local.tags
+  base_tags           = var.base_tags
+  private_dns         = var.private_dns
+  client_config       = var.client_config
+}

--- a/modules/databases/mssql_managed_instance/private_endpoints.tf
+++ b/modules/databases/mssql_managed_instance/private_endpoints.tf
@@ -6,7 +6,9 @@
 
 module "private_endpoint" {
   source   = "../../networking/private_endpoint"
-  for_each = var.private_endpoints
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   resource_id         = local.output.id
   name                = each.value.name
@@ -19,5 +21,24 @@ module "private_endpoint" {
   base_tags       = var.inherit_tags
   tags            = local.tags
   private_dns     = var.private_dns
+  client_config   = var.client_config
+}
+
+module "private_endpoint_v1" {
+  source   = "../../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
+
+  resource_id         = local.output.id
+  name                = each.value.name
+  location            = var.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
+  resource_group_name = var.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].name
+  subnet_id           = can(each.value.subnet_id) ? each.value.subnet_id : var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+
+  settings        = each.value
+  global_settings = var.global_settings
+  base_tags       = var.inherit_tags
+  tags            = local.tags
   client_config   = var.client_config
 }

--- a/modules/databases/mssql_managed_instance_v1/private_endpoints.tf
+++ b/modules/databases/mssql_managed_instance_v1/private_endpoints.tf
@@ -6,7 +6,9 @@
 
 module "private_endpoint" {
   source   = "../../networking/private_endpoint"
-  for_each = var.private_endpoints
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   resource_id         = azurerm_mssql_managed_instance.mssqlmi.id
   name                = each.value.name
@@ -19,5 +21,25 @@ module "private_endpoint" {
   base_tags       = var.inherit_tags
   tags            = local.tags
   private_dns     = var.private_dns
+  client_config   = var.client_config
+}
+
+
+module "private_endpoint_v1" {
+  source   = "../../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
+
+  resource_id         = azurerm_mssql_managed_instance.mssqlmi.id
+  name                = each.value.name
+  location            = var.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
+  resource_group_name = var.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].name
+  subnet_id           = can(each.value.subnet_id) ? each.value.subnet_id : var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+
+  settings        = each.value
+  global_settings = var.global_settings
+  base_tags       = var.inherit_tags
+  tags            = local.tags
   client_config   = var.client_config
 }

--- a/modules/databases/mssql_server/private_endpoints.tf
+++ b/modules/databases/mssql_server/private_endpoints.tf
@@ -6,7 +6,9 @@
 
 module "private_endpoint" {
   source   = "../../networking/private_endpoint"
-  for_each = var.private_endpoints
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   resource_id         = azurerm_mssql_server.mssql.id
   name                = each.value.name
@@ -19,5 +21,24 @@ module "private_endpoint" {
   base_tags       = var.base_tags
   tags            = local.tags
   private_dns     = var.private_dns
+  client_config   = var.client_config
+}
+
+module "private_endpoint_v1" {
+  source   = "../../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
+
+  resource_id         = azurerm_mssql_server.mssql.id
+  name                = each.value.name
+  location            = var.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
+  resource_group_name = var.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].name
+  subnet_id           = can(each.value.subnet_id) ? each.value.subnet_id : var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+
+  settings        = each.value
+  global_settings = var.global_settings
+  base_tags       = var.base_tags
+  tags            = local.tags
   client_config   = var.client_config
 }

--- a/modules/databases/mysql_flexible_server/private_endpoints.tf
+++ b/modules/databases/mysql_flexible_server/private_endpoints.tf
@@ -1,6 +1,8 @@
 module "private_endpoint" {
   source   = "../../networking/private_endpoint"
-  for_each = var.private_endpoints
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   resource_id = azurerm_mysql_flexible_server.mysql.id
   name        = each.value.name
@@ -16,5 +18,27 @@ module "private_endpoint" {
   base_tags       = var.inherit_base_tags
   tags            = local.tags
   private_dns     = var.private_dns
+  client_config   = var.client_config
+}
+
+module "private_endpoint_v1" {
+  source   = "../../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
+
+  resource_id = azurerm_mysql_flexible_server.mysql.id
+  name        = each.value.name
+  # location            = var.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
+  # resource_group_name = var.resource_groups[try(each.value.resource_group.lz_key, var.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+
+  subnet_id = can(each.value.subnet_id) ? each.value.subnet_id : var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+
+  settings        = each.value
+  global_settings = var.global_settings
+  base_tags       = var.inherit_base_tags
+  tags            = local.tags
   client_config   = var.client_config
 }

--- a/modules/databases/mysql_server/private_endpoints.tf
+++ b/modules/databases/mysql_server/private_endpoints.tf
@@ -4,7 +4,9 @@
 
 module "private_endpoint" {
   source   = "../../networking/private_endpoint"
-  for_each = try(var.private_endpoints, {})
+  for_each = {
+    for k,v in try(var.private_endpoints, {}) : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   resource_id         = azurerm_mysql_server.mysql.id
   name                = each.value.name
@@ -16,5 +18,23 @@ module "private_endpoint" {
   tags                = local.tags
   base_tags           = var.base_tags
   private_dns         = var.private_dns
+  client_config       = var.client_config
+}
+
+module "private_endpoint_v1" {
+  source   = "../../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in try(var.private_endpoints, {}) : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
+
+  resource_id         = azurerm_mysql_server.mysql.id
+  name                = each.value.name
+  location            = local.location
+  resource_group_name = local.resource_group_name
+  subnet_id           = can(each.value.subnet_id) ? each.value.subnet_id : var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+  settings            = each.value
+  global_settings     = var.global_settings
+  tags                = local.tags
+  base_tags           = var.base_tags
   client_config       = var.client_config
 }

--- a/modules/databases/postgresql_flexible_server/private_endpoint.tf
+++ b/modules/databases/postgresql_flexible_server/private_endpoint.tf
@@ -1,6 +1,8 @@
 module "private_endpoint" {
   source   = "../../networking/private_endpoint"
-  for_each = try(var.private_endpoints, {})
+  for_each = {
+    for k,v in try(var.private_endpoints, {}) : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   resource_id         = azurerm_postgresql_flexible_server.postgresql.id
   name                = each.value.name
@@ -12,5 +14,23 @@ module "private_endpoint" {
   base_tags           = var.base_tags
   tags                = local.tags
   private_dns         = var.private_dns
+  client_config       = var.client_config
+}
+
+module "private_endpoint_v1" {
+  source   = "../../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in try(var.private_endpoints, {}) : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
+
+  resource_id         = azurerm_postgresql_flexible_server.postgresql.id
+  name                = each.value.name
+  location            = local.location
+  resource_group_name = local.resource_group_name
+  subnet_id           = can(each.value.subnet_id) ? each.value.subnet_id : var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+  settings            = each.value
+  global_settings     = var.global_settings
+  base_tags           = var.base_tags
+  tags                = local.tags
   client_config       = var.client_config
 }

--- a/modules/databases/postgresql_server/private_endpoint.tf
+++ b/modules/databases/postgresql_server/private_endpoint.tf
@@ -1,6 +1,8 @@
 module "private_endpoint" {
   source   = "../../networking/private_endpoint"
-  for_each = try(var.private_endpoints, {})
+  for_each = {
+    for k,v in try(var.private_endpoints, {}) : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   resource_id         = azurerm_postgresql_server.postgresql.id
   name                = each.value.name
@@ -12,5 +14,23 @@ module "private_endpoint" {
   base_tags           = var.base_tags
   tags                = local.tags
   private_dns         = var.private_dns
+  client_config       = var.client_config
+}
+
+module "private_endpoint_v1" {
+  source   = "../../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in try(var.private_endpoints, {}) : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
+
+  resource_id         = azurerm_postgresql_server.postgresql.id
+  name                = each.value.name
+  location            = local.location
+  resource_group_name = local.resource_group_name
+  subnet_id           = can(each.value.subnet_id) ? each.value.subnet_id : var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+  settings            = each.value
+  global_settings     = var.global_settings
+  base_tags           = var.base_tags
+  tags                = local.tags
   client_config       = var.client_config
 }

--- a/modules/logic_app/standard/private_endpoint.tf
+++ b/modules/logic_app/standard/private_endpoint.tf
@@ -1,6 +1,8 @@
 module "private_endpoint" {
   source   = "../../networking/private_endpoint"
-  for_each = var.private_endpoints
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   resource_id         = azurerm_logic_app_standard.logic_app_standard.id
   name                = each.value.name
@@ -18,6 +20,31 @@ module "private_endpoint" {
   global_settings = var.global_settings
   base_tags       = var.base_tags
   private_dns     = var.private_dns
+  client_config   = var.client_config
+
+}
+
+module "private_endpoint_v1" {
+  source   = "../../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
+
+  resource_id         = azurerm_logic_app_standard.logic_app_standard.id
+  name                = each.value.name
+  location            = lookup(var.settings, "region", null) == null ? local.resource_group.location : var.global_settings.regions[var.settings.region]
+  resource_group_name = local.resource_group.name
+  subnet_id = coalesce(
+    try(each.value.subnet_id, null),
+    try(var.vnets[var.client_config.landingzone_key][each.value.vnet_key].subnets[each.value.subnet_key].id, null),
+    try(var.vnets[each.value.lz_key][each.value.vnet_key].subnets[each.value.subnet_key].id, null),
+    try(var.virtual_subnets[var.client_config.landingzone_key][each.value.subnet_key].id, null),
+    try(var.virtual_subnets[each.value.lz_key][each.value.subnet_key].id, null)
+  )
+
+  settings        = each.value
+  global_settings = var.global_settings
+  base_tags       = var.base_tags
   client_config   = var.client_config
 
 }

--- a/modules/messaging/eventgrid/eventgrid_domain/private_endpoints.tf
+++ b/modules/messaging/eventgrid/eventgrid_domain/private_endpoints.tf
@@ -4,7 +4,9 @@
 
 module "private_endpoint" {
   source   = "../../../networking/private_endpoint"
-  for_each = var.private_endpoints
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   resource_id         = azurerm_eventgrid_domain.egd.id
   name                = each.value.name
@@ -15,5 +17,22 @@ module "private_endpoint" {
   global_settings     = var.global_settings
   base_tags           = local.tags
   private_dns         = var.remote_objects.private_dns
+  client_config       = var.client_config
+}
+
+module "private_endpoint_v1" {
+  source   = "../../../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
+
+  resource_id         = azurerm_eventgrid_domain.egd.id
+  name                = each.value.name
+  location            = var.remote_objects.resource_groups[each.value.resource_group_key].location
+  resource_group_name = var.remote_objects.resource_groups[each.value.resource_group_key].name
+  subnet_id           = can(each.value.subnet_id) ? each.value.subnet_id : var.remote_objects.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+  settings            = each.value
+  global_settings     = var.global_settings
+  base_tags           = local.tags
   client_config       = var.client_config
 }

--- a/modules/messaging/servicebus/namespace/private_endpoints.tf
+++ b/modules/messaging/servicebus/namespace/private_endpoints.tf
@@ -29,7 +29,6 @@ module "private_endpoint_v1" {
   global_settings     = var.global_settings
   location            = local.location
   name                = each.value.name
-  private_dns         = can(each.value.private_dns) ? var.remote_objects.private_dns : {}
   resource_group_name = local.resource_group_name
   resource_id         = azurerm_servicebus_namespace.namespace.id
   settings            = each.value

--- a/modules/messaging/servicebus/namespace/private_endpoints.tf
+++ b/modules/messaging/servicebus/namespace/private_endpoints.tf
@@ -1,7 +1,27 @@
 module "private_endpoint" {
   source = "../../../networking/private_endpoint"
-  #for_each = try(var.settings.private_endpoints, {})
-  for_each = lookup(var.settings, "private_endpoints", {})
+  for_each = {
+    for k,v in lookup(var.settings, "private_endpoints", {}) : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
+
+  base_tags           = var.base_tags
+  tags                = local.tags
+  client_config       = var.client_config
+  global_settings     = var.global_settings
+  location            = local.location
+  name                = each.value.name
+  private_dns         = can(each.value.private_dns) ? var.remote_objects.private_dns : {}
+  resource_group_name = local.resource_group_name
+  resource_id         = azurerm_servicebus_namespace.namespace.id
+  settings            = each.value
+  subnet_id           = can(each.value.subnet_id) ? each.value.subnet_id : var.remote_objects.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+}
+
+module "private_endpoint_v1" {
+  source = "../../../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in lookup(var.settings, "private_endpoints", {}) : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
 
   base_tags           = var.base_tags
   tags                = local.tags

--- a/modules/messaging/web_pubsub/private_endpoint.tf
+++ b/modules/messaging/web_pubsub/private_endpoint.tf
@@ -1,6 +1,8 @@
 module "private_endpoint" {
   source   = "../../networking/private_endpoint"
-  for_each = try(var.settings.private_endpoints, {})
+  for_each = {
+    for k,v in lookup(var.settings, "private_endpoints", {}) : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   tags            = local.tags
   base_tags       = var.base_tags
@@ -9,6 +11,24 @@ module "private_endpoint" {
   location        = local.location
   name            = each.value.name
   private_dns     = var.remote_objects.private_dns
+  resource_groups = var.remote_objects.resource_groups
+  resource_id     = azurerm_web_pubsub.wps.id
+  settings        = each.value
+  subnet_id       = can(each.value.subnet_id) ? each.value.subnet_id : var.remote_objects.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+}
+
+module "private_endpoint_v1" {
+  source   = "../../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in lookup(var.settings, "private_endpoints", {}) : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
+
+  tags            = local.tags
+  base_tags       = var.base_tags
+  client_config   = var.client_config
+  global_settings = var.global_settings
+  location        = local.location
+  name            = each.value.name
   resource_groups = var.remote_objects.resource_groups
   resource_id     = azurerm_web_pubsub.wps.id
   settings        = each.value

--- a/modules/networking/private_endpoint/private_endpoint.tf
+++ b/modules/networking/private_endpoint/private_endpoint.tf
@@ -53,3 +53,12 @@ resource "azurerm_private_endpoint" "pep" {
     }
   }
 }
+
+resource "time_sleep" "delay" {
+  count           = can(lookup(var.settings, var.settings.delay_time_after_creation, false)) ? 1 : 0
+  depends_on      = [azurerm_private_endpoint.pep]
+  create_duration = var.settings.delay_time_after_creation
+  lifecycle {
+    replace_triggered_by = [azurerm_private_endpoint.pep]
+  }
+}

--- a/modules/networking/private_endpoint_v1/main.tf
+++ b/modules/networking/private_endpoint_v1/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    azurecaf = {
+      source = "aztfmod/azurecaf"
+    }
+  }
+
+}
+
+locals {
+  tags = var.base_tags ? merge(
+    var.global_settings.tags,
+    var.tags,
+    try(var.settings.tags, null)
+  ) : try(var.settings.tags, null)
+
+  location = can(var.location) || can(var.settings.region) ? try(var.location, var.global_settings.regions[var.settings.region]) : var.resource_groups[try(var.settings.resource_group.lz_key, var.settings.lz_key, var.client_config.landingzone_key)][try(var.settings.resource_group.key, var.settings.resource_group_key)].location
+
+  resource_group_name = can(var.resource_group_name) && var.resource_group_name != null ? var.resource_group_name : var.resource_groups[try(var.settings.resource_group.lz_key, var.settings.lz_key, var.client_config.landingzone_key)][try(var.settings.resource_group.key, var.settings.resource_group_key)].name
+
+}

--- a/modules/networking/private_endpoint_v1/output.tf
+++ b/modules/networking/private_endpoint_v1/output.tf
@@ -1,0 +1,14 @@
+output "id" {
+  value = azurerm_private_endpoint.pep.id
+
+}
+
+output "private_dns_zone_group" {
+  value = azurerm_private_endpoint.pep.private_dns_zone_group
+
+}
+
+output "private_dns_zone_configs" {
+  value = azurerm_private_endpoint.pep.private_dns_zone_configs
+
+}

--- a/modules/networking/private_endpoint_v1/private_endpoint.tf
+++ b/modules/networking/private_endpoint_v1/private_endpoint.tf
@@ -24,24 +24,6 @@ resource "azurerm_private_endpoint" "pep" {
     request_message                = try(var.settings.private_service_connection.request_message, null)
   }
 
-  dynamic "private_dns_zone_group" {
-    for_each = can(var.settings.private_dns) ? [var.settings.private_dns] : []
-
-    content {
-      name = lookup(private_dns_zone_group.value, "zone_group_name", "default")
-      private_dns_zone_ids = concat(
-        flatten([
-          for key in try(private_dns_zone_group.value.keys, []) : [
-            try(var.private_dns[try(private_dns_zone_group.value.lz_key, var.client_config.landingzone_key)][key].id, [])
-          ]
-          ]
-        ),
-        lookup(private_dns_zone_group.value, "ids", [])
-      )
-
-    }
-  }
-
   dynamic "ip_configuration" {
     for_each = try(var.settings.ip_configurations, {})
 
@@ -51,5 +33,20 @@ resource "azurerm_private_endpoint" "pep" {
       subresource_name   = lookup(ip_configuration.value, "subresource_name", null)
       member_name        = lookup(ip_configuration.value, "member_name", null)
     }
+  }
+
+  lifecycle {
+    ignore_changes = [ 
+      private_dns_zone_group
+    ]
+  }
+}
+
+resource "time_sleep" "delay" {
+  count           = can(lookup(var.settings, var.settings.delay_time_after_creation, false)) ? 1 : 0
+  depends_on      = [azurerm_private_endpoint.pep]
+  create_duration = var.settings.delay_time_after_creation
+  lifecycle {
+    replace_triggered_by = [azurerm_private_endpoint.pep]
   }
 }

--- a/modules/networking/private_endpoint_v1/variables.tf
+++ b/modules/networking/private_endpoint_v1/variables.tf
@@ -1,0 +1,39 @@
+variable "resource_id" {}
+
+variable "name" {
+  type        = string
+  description = "(Required) Specifies the name. Changing this forces a new resource to be created."
+}
+
+variable "resource_group_name" {
+  description = "The name of the resource group. Changing this forces a new resource to be created."
+  default     = null
+}
+variable "resource_groups" {
+  description = "The combined_objects of the resource groups. Changing this forces a new resource to be created."
+  default     = {}
+}
+
+variable "location" {
+  description = "Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created."
+  default     = null
+}
+
+variable "subnet_id" {}
+variable "settings" {}
+variable "global_settings" {
+  description = "Global settings object (see module README.md)"
+}
+variable "base_tags" {
+  description = "Base tags for the resource to be inherited from the resource group."
+  type        = bool
+}
+variable "subresource_names" {
+  default = []
+}
+variable "client_config" {
+  default = {}
+}
+variable "tags" {
+  default = {}
+}

--- a/modules/purview/purview_accounts/private_endpoints.tf
+++ b/modules/purview/purview_accounts/private_endpoints.tf
@@ -36,7 +36,6 @@ module "managed_resources_private_endpoints" {
   global_settings     = var.global_settings
   location            = local.location
   name                = each.value.name
-  private_dns         = var.private_dns
   resource_group_name = local.resource_group_name
   resource_id         = each.value.name == "eventhub" ? azurerm_purview_account.pva.managed_resources[0].event_hub_namespace_id : azurerm_purview_account.pva.managed_resources[0].storage_account_id
   settings            = each.value

--- a/modules/purview/purview_accounts/private_endpoints.tf
+++ b/modules/purview/purview_accounts/private_endpoints.tf
@@ -6,7 +6,9 @@
 
 module "private_endpoint" {
   source   = "../../networking/private_endpoint"
-  for_each = try(var.settings.private_endpoints, {})
+  for_each = {
+    for k,v in lookup(var.settings, "private_endpoints", {}) : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   base_tags           = var.base_tags
   tags                = local.tags
@@ -24,7 +26,9 @@ module "private_endpoint" {
 # Requires azurerm >=2.92.0
 module "managed_resources_private_endpoints" {
   source   = "../../networking/private_endpoint"
-  for_each = try(var.settings.managed_resources_private_endpoints, {})
+  for_each = {
+    for k,v in lookup(var.settings, "private_endpoints", {}) : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
 
   base_tags           = var.base_tags
   tags                = local.tags

--- a/modules/purview/purview_accounts/private_endpoints.tf
+++ b/modules/purview/purview_accounts/private_endpoints.tf
@@ -7,7 +7,7 @@
 module "private_endpoint" {
   source   = "../../networking/private_endpoint"
   for_each = {
-    for k,v in lookup(var.settings, "private_endpoints", {}) : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+    for k,v in var.settings.managed_resources_private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
   }
 
   base_tags           = var.base_tags
@@ -27,7 +27,7 @@ module "private_endpoint" {
 module "managed_resources_private_endpoints" {
   source   = "../../networking/private_endpoint"
   for_each = {
-    for k,v in lookup(var.settings, "private_endpoints", {}) : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+    for k,v in var.settings.managed_resources_private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
   }
 
   base_tags           = var.base_tags

--- a/modules/recovery_vault/private_endpoints.tf
+++ b/modules/recovery_vault/private_endpoints.tf
@@ -6,7 +6,9 @@
 
 module "private_endpoint" {
   source   = "../networking/private_endpoint"
-  for_each = var.private_endpoints
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   resource_id         = azurerm_recovery_services_vault.asr.id
   name                = each.value.name
@@ -19,5 +21,25 @@ module "private_endpoint" {
   tags                = local.tags
   base_tags           = var.base_tags
   private_dns         = var.private_dns
+  client_config       = var.client_config
+}
+
+
+module "private_endpoint_v1" {
+  source   = "../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
+
+  resource_id         = azurerm_recovery_services_vault.asr.id
+  name                = each.value.name
+  location            = local.location
+  resource_group_name = local.resource_group_name
+  subnet_id           = can(each.value.subnet_id) ? each.value.subnet_id : var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+  settings            = each.value
+  subresource_names   = ["AzureSiteRecovery"]
+  global_settings     = var.global_settings
+  tags                = local.tags
+  base_tags           = var.base_tags
   client_config       = var.client_config
 }

--- a/modules/redis_cache/private_endpoints.tf
+++ b/modules/redis_cache/private_endpoints.tf
@@ -6,7 +6,9 @@
 
 module "private_endpoint" {
   source   = "../networking/private_endpoint"
-  for_each = var.private_endpoints
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   resource_id         = azurerm_redis_cache.redis.id
   name                = each.value.name
@@ -18,5 +20,23 @@ module "private_endpoint" {
   tags                = local.tags
   base_tags           = var.base_tags
   private_dns         = var.private_dns
+  client_config       = var.client_config
+}
+
+module "private_endpoint_v1" {
+  source   = "../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
+
+  resource_id         = azurerm_redis_cache.redis.id
+  name                = each.value.name
+  location            = local.location
+  resource_group_name = local.resource_group_name
+  subnet_id           = can(each.value.subnet_id) ? each.value.subnet_id : var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+  settings            = each.value
+  global_settings     = var.global_settings
+  tags                = local.tags
+  base_tags           = var.base_tags
   client_config       = var.client_config
 }

--- a/modules/search_service/private_endpoint.tf
+++ b/modules/search_service/private_endpoint.tf
@@ -1,6 +1,8 @@
 module "private_endpoint" {
   source   = "../networking/private_endpoint"
-  for_each = var.private_endpoints
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   resource_id         = azurerm_search_service.search_service.id
   name                = each.value.name
@@ -15,4 +17,22 @@ module "private_endpoint" {
   client_config       = var.client_config
 }
 
+
+module "private_endpoint_v1" {
+  source   = "../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
+
+  resource_id         = azurerm_search_service.search_service.id
+  name                = each.value.name
+  location            = local.location
+  resource_group_name = local.resource_group_name
+  subnet_id           = can(each.value.subnet_id) || can(each.value.virtual_subnet_key) ? try(each.value.subnet_id, var.virtual_subnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.virtual_subnet_key].id) : var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+  settings            = each.value
+  global_settings     = var.global_settings
+  tags                = local.tags
+  base_tags           = var.base_tags
+  client_config       = var.client_config
+}
 

--- a/modules/security/keyvault/private_endpoints.tf
+++ b/modules/security/keyvault/private_endpoints.tf
@@ -6,7 +6,9 @@
 
 module "private_endpoint" {
   source   = "../../networking/private_endpoint"
-  for_each = lookup(var.settings, "private_endpoints", {})
+  for_each = {
+    for k,v in lookup(var.settings, "private_endpoints", {}) : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   resource_id         = azurerm_key_vault.keyvault.id
   name                = each.value.name
@@ -18,5 +20,23 @@ module "private_endpoint" {
   tags                = local.tags
   base_tags           = var.base_tags
   private_dns         = var.private_dns
+  client_config       = var.client_config
+}
+
+module "private_endpoint_v1" {
+  source   = "../../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in lookup(var.settings, "private_endpoints", {}) : k => v if try(v.ignore_private_dns_zone_group, false) == true
+  }
+
+  resource_id         = azurerm_key_vault.keyvault.id
+  name                = each.value.name
+  location            = local.location
+  resource_group_name = local.resource_group_name
+  subnet_id           = can(each.value.subnet_id) || can(each.value.vnet_key) == false ? try(each.value.subnet_id, var.virtual_subnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.subnet_key].id) : var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+  settings            = each.value
+  global_settings     = var.global_settings
+  tags                = local.tags
+  base_tags           = var.base_tags
   client_config       = var.client_config
 }

--- a/modules/storage_account/private_endpoint.tf
+++ b/modules/storage_account/private_endpoint.tf
@@ -1,6 +1,8 @@
 module "private_endpoint" {
   source   = "../networking/private_endpoint"
-  for_each = var.private_endpoints
+  for_each = {
+    for k,v in var.private_endpoints : k => v if try(v.ignore_private_dns_zone_group, false) == false
+  }
 
   resource_id         = azurerm_storage_account.stg.id
   name                = each.value.name
@@ -15,4 +17,20 @@ module "private_endpoint" {
   client_config       = var.client_config
 }
 
+module "private_endpoint_v1" {
+  source   = "../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in var.private_endpoints : k => v if try(v.ignore_private_dns_zone_group, false) == true
+  }
 
+  resource_id         = azurerm_storage_account.stg.id
+  name                = each.value.name
+  location            = local.location
+  resource_group_name = local.resource_group_name
+  subnet_id           = can(each.value.subnet_id) || can(each.value.virtual_subnet_key) ? try(each.value.subnet_id, var.virtual_subnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.virtual_subnet_key].id) : var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+  settings            = each.value
+  global_settings     = var.global_settings
+  tags                = local.tags
+  base_tags           = var.base_tags
+  client_config       = var.client_config
+}

--- a/modules/webapps/appservice/private_endpoint.tf
+++ b/modules/webapps/appservice/private_endpoint.tf
@@ -1,6 +1,8 @@
 module "private_endpoint" {
   source   = "../../networking/private_endpoint"
-  for_each = var.private_endpoints
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   resource_id         = azurerm_app_service.app_service.id
   name                = each.value.name
@@ -12,5 +14,23 @@ module "private_endpoint" {
   tags                = local.tags
   base_tags           = var.base_tags
   private_dns         = var.private_dns
+  client_config       = var.client_config
+}
+
+module "private_endpoint_v1" {
+  source   = "../../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
+
+  resource_id         = azurerm_app_service.app_service.id
+  name                = each.value.name
+  location            = local.location
+  resource_group_name = local.resource_group_name
+  subnet_id           = can(each.value.subnet_id) ? each.value.subnet_id : var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+  settings            = each.value
+  global_settings     = var.global_settings
+  tags                = local.tags
+  base_tags           = var.base_tags
   client_config       = var.client_config
 }

--- a/modules/webapps/function_app/private_endpoint.tf
+++ b/modules/webapps/function_app/private_endpoint.tf
@@ -1,6 +1,8 @@
 module "private_endpoint" {
   source   = "../../networking/private_endpoint"
-  for_each = var.private_endpoints
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == false
+  }
 
   resource_id         = azurerm_function_app.function_app.id
   name                = each.value.name
@@ -15,4 +17,20 @@ module "private_endpoint" {
   client_config       = var.client_config
 }
 
+module "private_endpoint_v1" {
+  source   = "../../networking/private_endpoint_v1"
+  for_each = {
+    for k,v in var.private_endpoints : k => v if lookup(v, "ignore_private_dns_zone_group", false) == true
+  }
 
+  resource_id         = azurerm_function_app.function_app.id
+  name                = each.value.name
+  location            = local.location
+  resource_group_name = local.resource_group_name
+  subnet_id           = can(each.value.subnet_id) || can(each.value.virtual_subnet_key) ? try(each.value.subnet_id, var.virtual_subnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.virtual_subnet_key].id) : var.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+  settings            = each.value
+  global_settings     = var.global_settings
+  tags                = local.tags
+  base_tags           = var.base_tags
+  client_config       = var.client_config
+}

--- a/modules/webapps/windows_web_app/slot.tf
+++ b/modules/webapps/windows_web_app/slot.tf
@@ -328,11 +328,4 @@ resource "azurerm_windows_web_app_slot" "slots" {
       }
     }
   }
-
-  lifecycle {
-    ignore_changes = [
-      app_settings["WEBSITE_RUN_FROM_PACKAGE"],
-      site_config[0].scm_type
-    ]
-  }
 }


### PR DESCRIPTION
## Description

In scenarios, where private endpoint dns is centrally managed, private endpoints dns is configured via policy. Hence terraform must ignore such changes. Otherwise, this could conflict drift and creates a loop of dns recreation introducing potential dns issues.

the PR introduces a new variable ignore_private_dns_zone_group to ignore future dns changes.

Adding ignore_private_dns_zone_group = true to existing private endpoint causes private endpoints to be recreated initially. Alternatively this could be managed using terraform moved block when applied locally.

## Does this introduce a breaking change

- [x] YES
- [] NO

## Testing
```
storage_accounts = {
 cache = {
    name                     = "cache"
    resource_group_key       = "runner"
    account_kind             = "StorageV2"
    account_tier             = "Standard"
    account_replication_type = "ZRS"
    private_endpoints = {
      sc_blob = {
        ignore_private_dns_zone_group = true
        resource_group_key = "runner"
        vnet_key           = "vnet"
        subnet_key         = "private_endpoints"
        name               = "sc-blob"
        private_service_connection = {
          name                 = "sc-blob-psc"
          is_manual_connection = false
          subresource_names    = ["Blob"]
        }
      }
    }
  }
}
```
