### PR TITLE
fix: conflicting lz_key reference

### DIFF
--- a/app_services.tf
+++ b/app_services.tf
@@ -73,7 +73,7 @@ module "linux_web_app" {
   storage_accounts                    = local.combined_objects_storage_accounts
   private_endpoints                   = try(each.value.private_endpoints, {})
   vnets                               = local.combined_objects_networking
-  subnet_id                           = can(each.value.subnet_id) || can(each.value.vnet_key) == false ? try(each.value.subnet_id, null) : local.combined_objects_networking[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+  subnet_id                           = can(each.value.vnet.subnet_id) || can(each.value.vnet.vnet_key) == false ? try(each.value.vnet.subnet_id, null) : local.combined_objects_networking[try(each.value.vnet.lz_key, local.client_config.landingzone_key)][each.value.vnet.vnet_key].subnets[each.value.vnet.subnet_key].id
   private_dns                         = local.combined_objects_private_dns
   azuread_applications                = local.combined_objects_azuread_applications
   azuread_service_principal_passwords = local.combined_objects_azuread_service_principal_passwords
@@ -110,7 +110,7 @@ module "windows_web_app" {
   storage_accounts                    = local.combined_objects_storage_accounts
   private_endpoints                   = try(each.value.private_endpoints, {})
   vnets                               = local.combined_objects_networking
-  subnet_id                           = can(each.value.subnet_id) || can(each.value.vnet_key) == false ? try(each.value.subnet_id, null) : local.combined_objects_networking[try(each.value.lz_key, local.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+  subnet_id                           = can(each.value.vnet.subnet_id) || can(each.value.vnet.vnet_key) == false ? try(each.value.vnet.subnet_id, null) : local.combined_objects_networking[try(each.value.vnet.lz_key, local.client_config.landingzone_key)][each.value.vnet.vnet_key].subnets[each.value.vnet.subnet_key].id
   private_dns                         = local.combined_objects_private_dns
   azuread_applications                = local.combined_objects_azuread_applications
   azuread_service_principal_passwords = local.combined_objects_azuread_service_principal_passwords


### PR DESCRIPTION
## Description

- app service plan and vnet reference are using same lz_key reference
- moved vnet reference into vnet block


## Does this introduce a breaking change

- [x] YES
- [ ] NO

vnet reference shall be made inside vnet block 

